### PR TITLE
fix: handle 404 when no code scanning analysis exists

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35644,12 +35644,24 @@ async function run() {
         });
         const octokit = github.getOctokit(token);
         // Fetch Code Scanning Alerts
-        let alerts = await octokit.paginate(octokit.rest.codeScanning.listAlertsForRepo, {
-            owner,
-            repo,
-            state: "open",
-            per_page: 100, // Fetch up to 100 alerts per page
-        });
+        let alerts;
+        try {
+            alerts = await octokit.paginate(octokit.rest.codeScanning.listAlertsForRepo, {
+                owner,
+                repo,
+                state: "open",
+                per_page: 100, // Fetch up to 100 alerts per page
+            });
+        }
+        catch (error) {
+            if (error.status === 404) {
+                core.info("No code scanning analyses found for this repository. Treating as 0 alerts.");
+                alerts = [];
+            }
+            else {
+                throw error;
+            }
+        }
         // Fetch files changed in the PR. If it's a PR workflow we are going to use this to filter alerts
         const prNumber = github.context.payload.pull_request?.number;
         let prFiles = [];

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -883,6 +883,44 @@ describe("run", () => {
     expect(mockSetOutput).toHaveBeenCalledWith("conclusion", "success");
   });
 
+  it("should succeed with 0 alerts when no analysis exists (404)", async () => {
+    mockGetInput.mockImplementation((name: string) => {
+      const inputs: Record<string, string> = {
+        github_token: "fake-token",
+        owner: "test-owner",
+        repo: "test-repo",
+        sha: "test-sha",
+        do_not_break_pr_check: "false",
+        max_critical_alerts: "0",
+        max_high_alerts: "0",
+        max_medium_alerts: "0",
+        max_low_alerts: "0",
+        max_note_alerts: "0",
+      };
+      return inputs[name];
+    });
+
+    // Ensure no PR context so the PR files fetch is skipped
+    (github.context as any).payload = {};
+
+    const notFoundError: any = new Error(
+      "no analysis found - https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-alerts-for-a-repository",
+    );
+    notFoundError.status = 404;
+    mockOctokit.paginate.mockRejectedValueOnce(notFoundError);
+
+    await run();
+
+    expect(mockSetOutput).toHaveBeenCalledWith("total_alerts", 0);
+    expect(mockSetOutput).toHaveBeenCalledWith("critical_alerts", 0);
+    expect(mockSetOutput).toHaveBeenCalledWith("high_alerts", 0);
+    expect(mockSetOutput).toHaveBeenCalledWith("medium_alerts", 0);
+    expect(mockSetOutput).toHaveBeenCalledWith("low_alerts", 0);
+    expect(mockSetOutput).toHaveBeenCalledWith("note_alerts", 0);
+    expect(mockSetOutput).toHaveBeenCalledWith("conclusion", "success");
+    expect(mockSetFailed).not.toHaveBeenCalled();
+  });
+
   it("should handle errors gracefully", async () => {
     const errorMessage = "Something went wrong";
     mockGetInput.mockImplementation(() => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -29,15 +29,27 @@ export async function run(): Promise<void> {
       github.getOctokit(token);
 
     // Fetch Code Scanning Alerts
-    let alerts = await octokit.paginate(
-      octokit.rest.codeScanning.listAlertsForRepo,
-      {
-        owner,
-        repo,
-        state: "open",
-        per_page: 100, // Fetch up to 100 alerts per page
-      },
-    );
+    let alerts: any[];
+    try {
+      alerts = await octokit.paginate(
+        octokit.rest.codeScanning.listAlertsForRepo,
+        {
+          owner,
+          repo,
+          state: "open",
+          per_page: 100, // Fetch up to 100 alerts per page
+        },
+      );
+    } catch (error: any) {
+      if (error.status === 404) {
+        core.info(
+          "No code scanning analyses found for this repository. Treating as 0 alerts.",
+        );
+        alerts = [];
+      } else {
+        throw error;
+      }
+    }
 
     // Fetch files changed in the PR. If it's a PR workflow we are going to use this to filter alerts
     const prNumber = github.context.payload.pull_request?.number;


### PR DESCRIPTION
On first deploy, `listAlertsForRepo` returns 404 because no analysis has been uploaded yet. This catches the specific error and treats it as 0 alerts instead of failing the action.

**Changes:**
- Wrap `listAlertsForRepo` paginate call in try-catch
- 404 → `alerts = []` → action succeeds with 0 alerts
- Other errors re-thrown (preserves existing behavior)
- New test case: `should succeed with 0 alerts when no analysis exists (404)`

All 11 tests passing.